### PR TITLE
Get 1.21.10 working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.10-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.13-SNAPSHOT" apply false
     id 'io.github.juuxel.loom-quiltflower' version '1.7.1' apply false
     id 'io.github.juuxel.loom-vineflower' version '1.11.0' apply false
     id "com.matthewprenger.cursegradle" version "1.4.0"

--- a/common/src/main/java/net/mehvahdjukaar/polytone/Polytone.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/Polytone.java
@@ -30,6 +30,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -138,7 +139,7 @@ public class Polytone {
     }
 
     public static void onEarlyPackLoad(ResourceManager manager) {
-        COMPOUND_RELOADER.earlyProcess(manager);
+        COMPOUND_RELOADER.earlyProcess(new PreparableReloadListener.SharedState(manager));
     }
 
     public static void logException(Exception e, String message) {

--- a/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
@@ -5,18 +5,15 @@ import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.DestFactor;
 import com.mojang.blaze3d.platform.SourceFactor;
-import com.mojang.blaze3d.shaders.UniformType;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexFormat;
-import net.mehvahdjukaar.polytone.compat.IrisCompat;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
-import net.minecraft.util.TriState;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 
 import java.util.function.Supplier;
@@ -70,8 +67,7 @@ public class PolytoneRenderTypes {
 
 
     public static final Supplier<ParticleRenderType> PARTICLE_ADDITIVE_TRANSLUCENCY_RENDER_TYPE = Suppliers.memoize(() ->
-            new ParticleRenderType("PARTICLE_SHEET_ADDITIVE_TRANSLUCENT",
-                    ADDITIVE_TRANSLUCENT_PARTICLE_RENDERTYPE));
+            new ParticleRenderType("PARTICLE_SHEET_ADDITIVE_TRANSLUCENT"));
 
 
     //block. Used to render 3d model for particles
@@ -127,17 +123,12 @@ public class PolytoneRenderTypes {
     }
 
 
-    public static boolean addLeashVertexPair(VertexConsumer vertexConsumer, Matrix4f matrix4f,
-                                        float startX, float startY, float startZ,
-                                        int blockLight0, int blockLight1, int skyLight0, int skylight1,
-                                        float y0, float y1,
-                                        float dx, float dz,
-                                        int index, boolean flippedColors) {
+    public static boolean addLeashVertexPair(VertexConsumer vertexConsumer, Matrix4f matrix4f, float startX, float startY, float startZ, float yOffset, float dx, float dz, int index, boolean bl, EntityRenderState.LeashState leashState) {
 
         // Calculate segment and interpolate lighting
         float segment = (float) index / 24.0F;
-        int blockLight = (int) Mth.lerp(segment, (float) blockLight0, (float) blockLight1);
-        int skyLight = (int) Mth.lerp(segment, (float) skyLight0, (float) skylight1);
+        int blockLight = (int) Mth.lerp(segment, (float) leashState.startBlockLight, (float) leashState.endBlockLight);
+        int skyLight = (int) Mth.lerp(segment, (float) leashState.startSkyLight, (float) leashState.endSkyLight);
         int light = LightTexture.pack(blockLight, skyLight);
 
         // Calculate vertex positions
@@ -151,18 +142,19 @@ public class PolytoneRenderTypes {
         float u2 = 1.0f;     // V-coordinate for the second vertex
 
         // Apply vertex attributes
-        vertexConsumer.addVertex(matrix4f, z - dx, aa + y1, ab + dz)
+        vertexConsumer.addVertex(matrix4f, z - dx, aa, ab + dz)
                 .setColor(1, 1, 1, 1f)
                 .setLight(light)
                 .setUv(u1, segment);
 
-        vertexConsumer.addVertex(matrix4f, z + dx, aa + y0 - y1, ab - dz)
+        vertexConsumer.addVertex(matrix4f, z + dx, aa + yOffset, ab - dz)
                 .setColor(1, 1, 1, 1f)
                 .setLight(light)
                 .setUv(u2, segment);
 
 
         return true;
+
     }
 };
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/biome/BiomeEffectsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/biome/BiomeEffectsManager.java
@@ -116,10 +116,14 @@ public class BiomeEffectsManager extends JsonPartialReloader {
         Player player = mc.player;
         if (player == null) return null;
 
-        //dont modify if a mob effect that modifies fog is active
-        if (FogRenderer.getPriorityFogFunction(player, mc.getDeltaTracker().getGameTimeDeltaPartialTick(false))
-                != null) return null;
 
+
+        //dont modify if a mob effect that modifies fog is active
+        /*
+             TODO: This is fairly complicated now since it would have to check all the fog environments to see
+             which are instances of MobEffectFogEnvironment and are currently applied.
+        if (FogRenderer.getPriorityFogFunction(player, mc.getDeltaTracker().getGameTimeDeltaPartialTick(false))
+                != null) return null;  */
         Level level = player.level();
 
         Holder<Biome> biome = ClientFrameTicker.getCameraBiome();

--- a/common/src/main/java/net/mehvahdjukaar/polytone/block/BlockPropertiesManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/block/BlockPropertiesManager.java
@@ -8,6 +8,7 @@ import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.colormap.ColormapsManager;
 import net.mehvahdjukaar.polytone.colormap.IndexCompoundColorGetter;
 import net.mehvahdjukaar.polytone.utils.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.BiomeColors;
@@ -18,6 +19,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.Level;
@@ -69,7 +71,8 @@ public class BlockPropertiesManager extends PartialReloader<BlockPropertiesManag
     }
 
     @Override
-    protected Resources prepare(ResourceManager resourceManager) {
+    protected Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
 
         Map<ResourceLocation, ArrayImage> textures = new HashMap<>();

--- a/common/src/main/java/net/mehvahdjukaar/polytone/dimension/DimensionEffectsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/dimension/DimensionEffectsManager.java
@@ -233,7 +233,7 @@ public class DimensionEffectsManager extends JsonImgPartialReloader {
         Colormap colormap = this.terrainFogColormaps.get(level.dimensionType());
         if (colormap == null) return original;
         isTerrainHack.set(true);
-        Vector4f vector4f = FogRenderer.computeFogColor(
+        Vector4f vector4f = Minecraft.getInstance().gameRenderer.fogRenderer.computeFogColor(
                 camera, partialTicks, level, minecraft.options.getEffectiveRenderDistance(),
                 gameRenderer.getDarkenWorldAmount(partialTicks), false
         );

--- a/common/src/main/java/net/mehvahdjukaar/polytone/dimension/DimensionEffectsModifier.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/dimension/DimensionEffectsModifier.java
@@ -10,7 +10,6 @@ import net.mehvahdjukaar.polytone.block.BlockContextExpression;
 import net.mehvahdjukaar.polytone.colormap.Colormap;
 import net.mehvahdjukaar.polytone.colormap.IColorGetter;
 import net.mehvahdjukaar.polytone.lightmap.Lightmap;
-import net.mehvahdjukaar.polytone.utils.Targets;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.resources.ResourceLocation;
@@ -22,7 +21,7 @@ import java.util.Optional;
 public record DimensionEffectsModifier(Optional<Either<Float, BlockContextExpression>> cloudLevel,
                                        Optional<Boolean> hasGround,
                                        Optional<DimensionSpecialEffects.SkyType> skyType,
-                                       Optional<Boolean> forceBrightLightmap,
+                                       Optional<Boolean> hasEndFlashes,
                                        Optional<Boolean> constantAmbientLight,
                                        Optional<IColorGetter> fogColor,
                                        Optional<IColorGetter> terrainFogColor,
@@ -41,7 +40,7 @@ public record DimensionEffectsModifier(Optional<Either<Float, BlockContextExpres
                     Codec.either(Codec.FLOAT, BlockContextExpression.CODEC).optionalFieldOf("cloud_level").forGetter(DimensionEffectsModifier::cloudLevel),
                     Codec.BOOL.optionalFieldOf("has_ground").forGetter(DimensionEffectsModifier::hasGround),
                     SKY_TYPE_CODEC.optionalFieldOf("sky_type").forGetter(DimensionEffectsModifier::skyType),
-                    Codec.BOOL.optionalFieldOf("force_bright_lightmap").forGetter(DimensionEffectsModifier::forceBrightLightmap),
+                    Codec.BOOL.optionalFieldOf("force_bright_lightmap").forGetter(DimensionEffectsModifier::hasEndFlashes),
                     Codec.BOOL.optionalFieldOf("constant_ambient_light").forGetter(DimensionEffectsModifier::constantAmbientLight),
                     Colormap.CODEC.optionalFieldOf("fog_colormap").forGetter(DimensionEffectsModifier::fogColor),
                     Colormap.CODEC.optionalFieldOf("terrain_fog_colormap").forGetter(DimensionEffectsModifier::terrainFogColor),
@@ -77,7 +76,7 @@ public record DimensionEffectsModifier(Optional<Either<Float, BlockContextExpres
                 newMod.cloudLevel.isPresent() ? newMod.cloudLevel : this.cloudLevel,
                 newMod.hasGround.isPresent() ? newMod.hasGround : this.hasGround,
                 newMod.skyType.isPresent() ? newMod.skyType : this.skyType,
-                newMod.forceBrightLightmap.isPresent() ? newMod.forceBrightLightmap : this.forceBrightLightmap,
+                newMod.hasEndFlashes.isPresent() ? newMod.hasEndFlashes : this.hasEndFlashes,
                 newMod.constantAmbientLight.isPresent() ? newMod.constantAmbientLight : this.constantAmbientLight,
                 newMod.fogColor.isPresent() ? newMod.fogColor : this.fogColor,
                 newMod.terrainFogColor.isPresent() ? newMod.terrainFogColor : this.terrainFogColor,
@@ -129,17 +128,18 @@ public record DimensionEffectsModifier(Optional<Either<Float, BlockContextExpres
             oldSky = Optional.of(effects.skyType);
             effects.skyType = this.skyType.get();
         }
-        Optional<Boolean> oldBright = Optional.empty();
-        if (this.forceBrightLightmap.isPresent()) {
-            oldBright = Optional.of(effects.forceBrightLightmap);
-            effects.forceBrightLightmap = this.forceBrightLightmap.get();
+
+        Optional<Boolean> oldEndFlashes = Optional.empty();
+        if (this.hasEndFlashes.isPresent()) {
+            oldEndFlashes = Optional.of(effects.hasEndFlashes());
+            effects.hasEndFlashes = this.hasEndFlashes.get();
         }
         Optional<Boolean> oldAmbient = Optional.empty();
         if (this.constantAmbientLight.isPresent()) {
             oldAmbient = Optional.of(effects.constantAmbientLight);
             effects.constantAmbientLight = this.constantAmbientLight.get();
         }
-        return new DimensionEffectsModifier(oldCloud, oldGround, oldSky, oldBright, oldAmbient,
+        return new DimensionEffectsModifier(oldCloud, oldGround, oldSky, oldEndFlashes, oldAmbient,
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 false, false, Optional.empty(), DimensionTarget.EMPTY);
     }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/fluid/FluidPropertiesManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/fluid/FluidPropertiesManager.java
@@ -8,12 +8,14 @@ import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.colormap.Colormap;
 import net.mehvahdjukaar.polytone.colormap.ColormapsManager;
 import net.mehvahdjukaar.polytone.utils.*;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.material.Fluid;
@@ -42,7 +44,8 @@ public class FluidPropertiesManager extends JsonImgPartialReloader {
     }
 
     @Override
-    protected Resources prepare(ResourceManager resourceManager) {
+    protected Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
 
         Map<ResourceLocation, ArrayImage> textures = new HashMap<>();

--- a/common/src/main/java/net/mehvahdjukaar/polytone/item/CustomItemModelsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/item/CustomItemModelsManager.java
@@ -6,10 +6,12 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.utils.JsonPartialReloader;
 import net.mehvahdjukaar.polytone.utils.Parsed;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
@@ -40,7 +42,8 @@ public class CustomItemModelsManager extends JsonPartialReloader {
     }
 
     @Override
-    protected void earlyProcess(ResourceManager resourceManager) {
+    protected void earlyProcess(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = getJsonsInDirectories(resourceManager);
         /* //TODO: add back someday
         for (var e : Parsed.batchParseOnlyEnabled(jsons, StandaloneItemModelOverride.CODEC_MODEL_ONLY,

--- a/common/src/main/java/net/mehvahdjukaar/polytone/lightmap/Lightmap.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/lightmap/Lightmap.java
@@ -173,7 +173,7 @@ public class Lightmap {
         Vector3f skyColor = (new Vector3f(skyDarken, skyDarken, 1.0F))
                 .lerp(new Vector3f(1.0F, 1.0F, 1.0F), 0.35F);
         float blockLightFlicker = flicker + 1.5F;
-        //boolean endBright = level.effects().forceBrightLightmap();
+        //boolean endBright = level.effects().hasEndFlashes();
         DimensionType dimensionType = level.dimensionType();
 
         float darkenWorldAmount = minecraft.gameRenderer.getDarkenWorldAmount(partialTicks);

--- a/common/src/main/java/net/mehvahdjukaar/polytone/lightmap/LightmapsManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/lightmap/LightmapsManager.java
@@ -19,6 +19,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
@@ -46,7 +47,8 @@ public class LightmapsManager extends JsonImgPartialReloader {
     }
 
     @Override
-    protected Resources prepare(ResourceManager resourceManager) {
+    protected Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
 
         Map<ResourceLocation, ArrayImage> textures = new HashMap<>();

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/AbstractContainerMenuMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/AbstractContainerMenuMixin.java
@@ -13,10 +13,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(AbstractContainerMenu.class)
 public abstract class AbstractContainerMenuMixin {
 
-    @Inject(method = "addSlot", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/core/NonNullList;add(Ljava/lang/Object;)Z",
-            ordinal = 0),
-            require = 1)
+//    @Inject(method = "addSlot", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/core/NonNullList;add(Ljava/lang/Object;)Z",
+//            ordinal = 0),
+//            require = 1)
     public void interact(Slot slot, CallbackInfoReturnable<Slot> cir,
                          @Local(argsOnly = true) LocalRef<Slot> mutableSlot) {
         Polytone.SLOTIFY.maybeModifySlot((AbstractContainerMenu) (Object) this, slot);

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/FogRendererMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/FogRendererMixin.java
@@ -15,8 +15,9 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(FogRenderer.class)
 public abstract class FogRendererMixin {
 
-    @WrapOperation(method = "computeFogColor", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/util/CubicSampler;gaussianSampleVec3(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/util/CubicSampler$Vec3Fetcher;)Lnet/minecraft/world/phys/Vec3;"))
+    // TODO: - need to be setupfog on atomospheric environment now
+//    @WrapOperation(method = "computeFogColor", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/util/CubicSampler;gaussianSampleVec3(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/util/CubicSampler$Vec3Fetcher;)Lnet/minecraft/world/phys/Vec3;"))
     private static Vec3 polytone$modifyFogColor(Vec3 center, CubicSampler.Vec3Fetcher fetcher,
                                                 Operation<Vec3> original, @Local(argsOnly = true) ClientLevel level,
                                                 @Local(argsOnly = true) int renderDistanceChunks,
@@ -29,8 +30,8 @@ public abstract class FogRendererMixin {
     }
 
 
-    @ModifyExpressionValue(method = "computeFogColor", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/multiplayer/ClientLevel;getRainLevel(F)F"))
+//    @ModifyExpressionValue(method = "computeFogColor", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/client/multiplayer/ClientLevel;getRainLevel(F)F"))
     private static float polytone$modifyRainFog(float original, @Local(argsOnly = true) ClientLevel level) {
         if (original != 0 && Polytone.DIMENSION_MODIFIERS.shouldCancelFogWeatherDarken(level)) {
             return 0;
@@ -38,8 +39,8 @@ public abstract class FogRendererMixin {
         return original;
     }
 
-    @ModifyExpressionValue(method = "computeFogColor", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/multiplayer/ClientLevel;getThunderLevel(F)F"))
+//    @ModifyExpressionValue(method = "computeFogColor", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/client/multiplayer/ClientLevel;getThunderLevel(F)F"))
     private static float polytone$modifyThunderFog(float original, @Local(argsOnly = true) ClientLevel level) {
         if (original != 0 && Polytone.DIMENSION_MODIFIERS.shouldCancelFogWeatherDarken(level)) {
             return 0;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GameRendererMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GameRendererMixin.java
@@ -19,7 +19,7 @@ public abstract class GameRendererMixin {
     private LightTexture lightTexture;
 
     @Inject(method = "render", at = @At(value = "NEW",
-            target = "(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;)Lnet/minecraft/client/gui/GuiGraphics;"))
+            target = "(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/render/state/GuiRenderState;)Lnet/minecraft/client/gui/GuiGraphics;"))
     private void polytone$messWithGui(DeltaTracker deltaTracker, boolean bl, CallbackInfo ci) {
         Polytone.LIGHTMAPS.setupForGUI(true);
         lightTexture.turnOnLightLayer();

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GuiMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GuiMixin.java
@@ -15,9 +15,9 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @Mixin(Gui.class)
 public abstract class GuiMixin {
 
-    @ModifyArg(method = "renderExperienceLevel", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Ljava/lang/String;IIIZ)I",
-            ordinal = 4), index = 4)
+//    @ModifyArg(method = "renderExperienceLevel", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Ljava/lang/String;IIIZ)I",
+//            ordinal = 4), index = 4)
     public int polytone$changeXpColor(Font font, @Nullable String text, int x, int y, int color, boolean dropShadow) {
         Integer newCol = Polytone.COLORS.getXpBar();
         return newCol != null ? newCol : color;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GuiRenderStateMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/GuiRenderStateMixin.java
@@ -1,11 +1,14 @@
 package net.mehvahdjukaar.polytone.mixins;
 
+import com.mojang.logging.LogUtils;
+import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.utils.GuiDepthTarget;
 import net.mehvahdjukaar.polytone.utils.GuiDepthTargetAware;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.state.GuiRenderState;
 import net.minecraft.client.gui.render.state.ScreenArea;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -76,13 +79,13 @@ public abstract class GuiRenderStateMixin implements GuiDepthTargetAware {
             current = current.up;
             depth++;
         }
-
+        /* Not possible anymore
         // Traverse down to target node (if possible)
         while (depth > nodeIndex && current.down != null) {
             current = current.down;
             depth--;
         }
-
+*/
         // Check if current satisfies the predicate
         if (predicate.test(current)) {
             this.current = current;
@@ -94,20 +97,22 @@ public abstract class GuiRenderStateMixin implements GuiDepthTargetAware {
 
         if (addAbove) {
             // Insert above
-            newNode.down = current;
+            /*newNode.down = current;*/
             newNode.up = current.up;
-            if (current.up != null) {
+            /*if (current.up != null) {
                 current.up.down = newNode;
-            }
+            }*/
             current.up = newNode;
         } else {
+            Polytone.LOGGER.error("Can't insert below anymore!");
+            /*
             // Insert below
             newNode.up = current;
             newNode.down = current.down;
             if (current.down != null) {
                 current.down.up = newNode;
             }
-            current.down = newNode;
+            current.down = newNode; */
         }
 
         this.current = newNode;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/LeashMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/LeashMixin.java
@@ -7,18 +7,20 @@ import net.mehvahdjukaar.polytone.PolytoneRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.feature.LeashFeatureRenderer;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(value = EntityRenderer.class, priority = 1300)
+@Mixin(value = LeashFeatureRenderer.class, priority = 1300)
 public class LeashMixin {
 
     @Inject(method = "addVertexPair", at = @At("HEAD"), cancellable = true)
-    private static void polytone$modifyLeashRender(VertexConsumer vertexConsumer, Matrix4f matrix4f, float f, float g, float h, int i, int j, int k, int l, float m, float n, float o, float p, int q, boolean bl, CallbackInfo ci) {
-        if (PolytoneRenderTypes.addLeashVertexPair(vertexConsumer, matrix4f, f, g, h, i, j, k, l, m, n, o, p, q, bl)) {
+    private static void polytone$modifyLeashRender(VertexConsumer vertexConsumer, Matrix4f matrix4f, float f, float g, float h, float i, float j, float k, int l, boolean bl, EntityRenderState.LeashState leashState, CallbackInfo ci) {
+        if (PolytoneRenderTypes.addLeashVertexPair(vertexConsumer, matrix4f, f, g, h, i, j, k, l, bl, leashState)) {
             ci.cancel();
         }
     }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/LevelRendererMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/LevelRendererMixin.java
@@ -38,16 +38,16 @@ public class LevelRendererMixin {
     }
 
 
-    @ModifyArg(method = "renderLevel",
-            at = @At(value = "INVOKE",
-                    ordinal = 0,
-                    target = "Lnet/minecraft/client/renderer/FogRenderer;setupFog(Lnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/FogRenderer$FogMode;Lorg/joml/Vector4f;FZF)Lnet/minecraft/client/renderer/FogParameters;"))
+//    @ModifyArg(method = "renderLevel",
+//            at = @At(value = "INVOKE",
+//                    ordinal = 0,
+//                    target = "Lnet/minecraft/client/renderer/fog/environment/FogEnvironment;setupFog(Lnet/minecraft/client/renderer/fog/FogData;Lnet/minecraft/client/renderer/FogRenderer$FogMode;Lorg/joml/Vector4f;FZF)Lnet/minecraft/client/renderer/FogParameters;"))
     private Vector4f polytone$modifyTerrainFogColor(Vector4f original, @Local(argsOnly = true) Camera camera,
                                                     @Local(ordinal = 1) float partialTicks,
                                                     @Local(argsOnly = true) GameRenderer gameRenderer) {
-
-        return Polytone.DIMENSION_MODIFIERS.modifyTerrainFogColor(original, this.level,
-                camera, partialTicks, gameRenderer, this.minecraft);
+        return original;
+//        return Polytone.DIMENSION_MODIFIERS.modifyTerrainFogColor(original, this.level,
+//                camera, partialTicks, gameRenderer, this.minecraft);
     }
 
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/ParticleEngineMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/ParticleEngineMixin.java
@@ -39,22 +39,22 @@ public abstract class ParticleEngineMixin {
         return original;
     }
 
-    @Inject(method = "reload", at = @At(value = "HEAD"))
-    public void polytone$addPackSpriteSets(PreparableReloadListener.PreparationBarrier preparationBarrier, ResourceManager resourceManager, Executor executor, Executor executor2, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-        Polytone.CUSTOM_PARTICLES.addSpriteSets(resourceManager);
-    }
-
-    @ModifyArg(method = "method_18125",
-            require = 0, //low priority
-            at = @At(value = "INVOKE", target = "Lcom/google/common/collect/EvictingQueue;create(I)Lcom/google/common/collect/EvictingQueue;"))
-    private static int polytone$modifyEvictingQueueSize(int size) {
-        return size * 50;
-    }
-
-    @Inject(method = "destroy", at = @At("HEAD"))
-    public void polytone$addExtraDestroyParticles(BlockPos pos, BlockState state, CallbackInfo ci) {
-        if(!state.isAir()){
-            Polytone.BLOCK_MODIFIERS.runTickers(state, this.level, pos, TickSource.BLOCK_BROKEN);
-        }
-    }
+//    @Inject(method = "reload", at = @At(value = "HEAD"))
+//    public void polytone$addPackSpriteSets(PreparableReloadListener.PreparationBarrier preparationBarrier, ResourceManager resourceManager, Executor executor, Executor executor2, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+//        Polytone.CUSTOM_PARTICLES.addSpriteSets(resourceManager);
+//    }
+//
+//    @ModifyArg(method = "method_18125",
+//            require = 0, //low priority
+//            at = @At(value = "INVOKE", target = "Lcom/google/common/collect/EvictingQueue;create(I)Lcom/google/common/collect/EvictingQueue;"))
+//    private static int polytone$modifyEvictingQueueSize(int size) {
+//        return size * 50;
+//    }
+//
+//    @Inject(method = "destroy", at = @At("HEAD"))
+//    public void polytone$addExtraDestroyParticles(BlockPos pos, BlockState state, CallbackInfo ci) {
+//        if(!state.isAir()){
+//            Polytone.BLOCK_MODIFIERS.runTickers(state, this.level, pos, TickSource.BLOCK_BROKEN);
+//        }
+//    }
 }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/ParticleResourcesMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/ParticleResourcesMixin.java
@@ -1,0 +1,38 @@
+package net.mehvahdjukaar.polytone.mixins;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.mehvahdjukaar.polytone.Polytone;
+import net.mehvahdjukaar.polytone.block.TickSource;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.particle.ParticleResources;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+
+@Mixin(ParticleResources.class)
+public abstract class ParticleResourcesMixin {
+
+
+    @Inject(method = "reload", at = @At(value = "HEAD"))
+    public void polytone$addPackSpriteSets(PreparableReloadListener.SharedState sharedState, Executor executor, PreparableReloadListener.PreparationBarrier preparationBarrier, Executor executor2, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+        Polytone.CUSTOM_PARTICLES.addSpriteSets(sharedState.resourceManager());
+    }
+
+}

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/SmithingScreenMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/SmithingScreenMixin.java
@@ -26,34 +26,34 @@ public class SmithingScreenMixin {
 
         return x;
     }
-
-    @ModifyArg(method = "renderBg", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;renderEntityInInventory(Lnet/minecraft/client/gui/GuiGraphics;FFFLorg/joml/Vector3f;Lorg/joml/Quaternionf;Lorg/joml/Quaternionf;Lnet/minecraft/world/entity/LivingEntity;)V")
-            , index = 2
-    )
-    public float modifyRenderEntityY(float y) {
-        var m = ((SlotifyScreen) this).polytone$getModifier();
-        if (m != null) {
-            var s = m.getSpecial("player");
-            if (s != null) {
-                return y + s.y();
-            }
-        }
-        return y;
-    }
-
-    @ModifyArg(method = "renderBg", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;renderEntityInInventory(Lnet/minecraft/client/gui/GuiGraphics;FFFLorg/joml/Vector3f;Lorg/joml/Quaternionf;Lorg/joml/Quaternionf;Lnet/minecraft/world/entity/LivingEntity;)V")
-            , index = 3
-    )
-    public float modifyRenderEntityScale(float z) {
-        var m = ((SlotifyScreen) this).polytone$getModifier();
-        if (m != null) {
-            var s = m.getSpecial("player");
-            if (s != null) {
-                return z + s.z();
-            }
-        }
-        return z;
-    }
+//
+//    @ModifyArg(method = "renderBg", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;renderEntityInInventory(Lnet/minecraft/client/gui/GuiGraphics;FFFLorg/joml/Vector3f;Lorg/joml/Quaternionf;Lorg/joml/Quaternionf;Lnet/minecraft/world/entity/LivingEntity;)V")
+//            , index = 2
+//    )
+//    public float modifyRenderEntityY(float y) {
+//        var m = ((SlotifyScreen) this).polytone$getModifier();
+//        if (m != null) {
+//            var s = m.getSpecial("player");
+//            if (s != null) {
+//                return y + s.y();
+//            }
+//        }
+//        return y;
+//    }
+//
+//    @ModifyArg(method = "renderBg", at = @At(value = "INVOKE",
+//            target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;renderEntityInInventory(Lnet/minecraft/client/gui/GuiGraphics;FFFLorg/joml/Vector3f;Lorg/joml/Quaternionf;Lorg/joml/Quaternionf;Lnet/minecraft/world/entity/LivingEntity;)V")
+//            , index = 3
+//    )
+//    public float modifyRenderEntityScale(float z) {
+//        var m = ((SlotifyScreen) this).polytone$getModifier();
+//        if (m != null) {
+//            var s = m.getSpecial("player");
+//            if (s != null) {
+//                return z + s.z();
+//            }
+//        }
+//        return z;
+//    }
 }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/mixins/XpOrbMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/mixins/XpOrbMixin.java
@@ -5,9 +5,11 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.mehvahdjukaar.polytone.Polytone;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.ExperienceOrbRenderer;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.entity.state.ExperienceOrbRenderState;
+import net.minecraft.client.renderer.state.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.world.entity.ExperienceOrb;
 import org.jetbrains.annotations.Nullable;
@@ -23,15 +25,15 @@ public class XpOrbMixin {
     @Unique
     private static float @Nullable [] polytone$specialColor = null;
 
-    @Inject(method = "render(Lnet/minecraft/client/renderer/entity/state/ExperienceOrbRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+    @Inject(method = "submit(Lnet/minecraft/client/renderer/entity/state/ExperienceOrbRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
             at = @At("HEAD"))
-    private void polytone$startRenderOrb(ExperienceOrbRenderState experienceOrbRenderState, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci) {
+    private void polytone$startRenderOrb(ExperienceOrbRenderState experienceOrbRenderState, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CameraRenderState cameraRenderState, CallbackInfo ci) {
         polytone$specialColor = Polytone.COLORS.getXpOrbColor(experienceOrbRenderState, Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(false));
     }
 
-    @Inject(method = "render(Lnet/minecraft/client/renderer/entity/state/EntityRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+    @Inject(method = "submit(Lnet/minecraft/client/renderer/entity/state/ExperienceOrbRenderState;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;Lnet/minecraft/client/renderer/state/CameraRenderState;)V",
             at = @At("TAIL"))
-    private void polytone$endRenderOrb(EntityRenderState entityRenderState, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci) {
+    private void polytone$endRenderOrb(ExperienceOrbRenderState experienceOrbRenderState, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CameraRenderState cameraRenderState, CallbackInfo ci) {
         polytone$specialColor = null;
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticleFactory.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticleFactory.java
@@ -2,23 +2,25 @@ package net.mehvahdjukaar.polytone.particle;
 
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
-import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 public interface CustomParticleFactory extends ParticleProvider<ExtraDataParticleOptions> {
 
-    void setSpriteSet(ParticleEngine.MutableSpriteSet spriteSet);
+    void setSpriteSet(SpriteSet spriteSet);
 
     @Nullable
-    Particle createParticle(ExtraDataParticleOptions type, ClientLevel world, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
-                            @Nullable BlockState state);
+    Particle createParticleWithState(ExtraDataParticleOptions type, ClientLevel world, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
+                            @Nullable BlockState state, RandomSource random);
 
     @Nullable
-    default Particle createParticle(ExtraDataParticleOptions type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
-        return createParticle(type, level, x, y, z, xSpeed, ySpeed, zSpeed, null);
+    @Override
+    default Particle createParticle(ExtraDataParticleOptions type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, RandomSource random) {
+        return createParticleWithState(type, level, x, y, z, xSpeed, ySpeed, zSpeed, null, random);
     }
 
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticleType.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticleType.java
@@ -18,11 +18,13 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.resources.model.QuadCollection;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.particles.ParticleGroup;
+import net.minecraft.core.particles.ParticleLimit;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.util.Mth;
@@ -32,6 +34,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Quaternionf;
 
@@ -40,6 +43,8 @@ import java.util.*;
 public class CustomParticleType implements CustomParticleFactory {
 
     private static BlockState STATE_HACK = Blocks.AIR.defaultBlockState();
+    private static SingleQuadParticle.Layer CUSTOM_LAYER = new SingleQuadParticle.Layer(true, TextureAtlas.LOCATION_PARTICLES, RenderPipelines.TRANSLUCENT);
+    private static SingleQuadParticle.Layer ADDITIVE_TRANSLUCENT = new SingleQuadParticle.Layer(true, TextureAtlas.LOCATION_PARTICLES, PolytoneRenderTypes.ADDITIVE_TRANSLUCENT_PARTICLE_PIPELINE);
 
     private final RenderType renderType;
     private final @Nullable ResourceLocation model;
@@ -60,7 +65,7 @@ public class CustomParticleType implements CustomParticleFactory {
     private final @Nullable IColorGetter colormap;
     private final RotationProvider rotationProvider;
     private final Vec3 offset;
-    private final Optional<ParticleGroup> group;
+    private final Optional<ParticleLimit> group;
     private final boolean forceSpawn;
     private final boolean randomSprite;
 
@@ -95,7 +100,7 @@ public class CustomParticleType implements CustomParticleFactory {
         this.rotationProvider = rotationProvider;
         this.tickRate = tickRate;
         this.exclusionRadius = killSimilarInRadius;
-        this.group = particleGroupLimit > 0 ? Optional.of(new ParticleGroup(particleGroupLimit)) : Optional.empty();
+        this.group = particleGroupLimit > 0 ? Optional.of(new ParticleLimit(particleGroupLimit)) : Optional.empty();
     }
 
     public static final Codec<CustomParticleType> CODEC = RecordCodecBuilder.create(i -> BiggerCodecs.group(i,
@@ -112,7 +117,7 @@ public class CustomParticleType implements CustomParticleFactory {
             Colormap.CODEC.optionalFieldOf("colormap").forGetter(c -> Optional.ofNullable(c.colormap)),
             Codec.BOOL.optionalFieldOf("random_sprite", false).forGetter(c -> c.randomSprite),
             ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("limit", 0).forGetter(c ->
-                    c.group.map(ParticleGroup::getLimit).orElse(0)),
+                    c.group.map(ParticleLimit::limit).orElse(0)),
             Codec.BOOL.optionalFieldOf("force_spawn", false).forGetter(c -> c.forceSpawn),
             ParticleInitializer.CODEC.optionalFieldOf("initializer").forGetter(c -> Optional.ofNullable(c.initializer)),
             Ticker.CODEC.optionalFieldOf("ticker").forGetter(c -> Optional.ofNullable(c.ticker)),
@@ -154,12 +159,12 @@ public class CustomParticleType implements CustomParticleFactory {
     }
 
     @Override
-    public Particle createParticle(ExtraDataParticleOptions opt, ClientLevel world, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
-                                   @Nullable BlockState state) {
+    public Particle createParticleWithState(ExtraDataParticleOptions opt, ClientLevel world, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
+                                   @Nullable BlockState state, RandomSource random) {
         if (spriteSet != null) {
             // some people might want this
 
-            Instance newParticle = new Instance(world, x, y, z, xSpeed, ySpeed, zSpeed, state, this);
+            Instance newParticle = new Instance(world, x, y, z, xSpeed, ySpeed, zSpeed, state, this, random);
             opt.apply(newParticle);
             if (this.hasPhysics) {
                 for (VoxelShape voxelShape : world.getBlockCollisions(null, newParticle.getBoundingBox())) {
@@ -175,12 +180,12 @@ public class CustomParticleType implements CustomParticleFactory {
                 }
             }
             if (exclusionRadius > 0) {
-                var particleRenderType = this.renderType.getParticle();
+                var particleRenderType = ParticleRenderType.SINGLE_QUADS;
                 double radiusSquared = exclusionRadius * exclusionRadius;
-                Queue<Particle> particleQueue = Minecraft.getInstance().particleEngine.particles.get(particleRenderType);
+                var  particleQueue = Minecraft.getInstance().particleEngine.particles.get(particleRenderType);
 
                 if (particleQueue != null) {
-                    for (var p : particleQueue) {
+                    for (var p : particleQueue.getAll()) {
                         if (p instanceof Instance inst && inst.type == this) {
                             //calculate distance between p and newParticle
                             double distSqrt = Mth.lengthSquared(
@@ -208,15 +213,15 @@ public class CustomParticleType implements CustomParticleFactory {
     }
 
     @Override
-    public void setSpriteSet(ParticleEngine.MutableSpriteSet mutableSpriteSet) {
-        this.spriteSet = mutableSpriteSet;
+    public void setSpriteSet(SpriteSet spriteSet) {
+        this.spriteSet = spriteSet;
     }
 
     public void setUnregistered() {
         this.isValid = false;
     }
 
-    public static class Instance extends TextureSheetParticle {
+    public static class Instance extends SingleQuadParticle {
 
         protected final CustomParticleType type;
         protected final @Nullable QuadCollection model;
@@ -227,8 +232,18 @@ public class CustomParticleType implements CustomParticleFactory {
         protected double custom;
 
         protected Instance(ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
-                           @Nullable BlockState state, CustomParticleType customType) {
-            super(level, x, y, z, xSpeed, ySpeed, zSpeed);
+                           @Nullable BlockState state, CustomParticleType customType, RandomSource random) {
+            super(level, x, y, z, xSpeed, ySpeed, zSpeed, customType.randomSprite ? customType.spriteSet.get(random) : customType.spriteSet.first());
+            if (customType.randomSprite) {
+                this.spriteSet = null;
+                this.setSprite(customType.spriteSet.get(random));
+
+            } else {
+                this.spriteSet = customType.spriteSet;
+                this.setSpriteFromAge(spriteSet);
+            }
+
+
             this.setSize(0.1f, 0.1f);
             this.type = customType;
 
@@ -263,14 +278,6 @@ public class CustomParticleType implements CustomParticleFactory {
                 this.setColor(unpack[0], unpack[1], unpack[2]);
             }
 
-            if (customType.randomSprite) {
-                this.spriteSet = null;
-                this.pickSprite(customType.spriteSet);
-
-            } else {
-                this.spriteSet = customType.spriteSet;
-                this.setSpriteFromAge(spriteSet);
-            }
         }
 
         private boolean hasAgeLeft() {
@@ -282,10 +289,13 @@ public class CustomParticleType implements CustomParticleFactory {
         }
 
         @Override
-        public Optional<ParticleGroup> getParticleGroup() {
+        public @NotNull Optional<ParticleLimit> getParticleLimit() {
             return this.type.group;
         }
-
+/* TODO: these require a different approach now if you want to allow overriding the full rendering.
+            Otherwise, SingleQuadParticle already does this.
+*/
+/*
         @Override
         public void render(VertexConsumer buffer, Camera camera, float partialTicks) {
             Quaternionf quaternionf = new Quaternionf();
@@ -342,7 +352,7 @@ public class CustomParticleType implements CustomParticleFactory {
             super.renderRotatedQuad(consumer, quaternion, (float) (x + offset.x),
                     (float) (y + offset.y), (float) (z + offset.z), partialTicks);
         }
-
+*/
         @Override
         protected int getLightColor(float partialTick) {
             int total = super.getLightColor(partialTick);
@@ -434,9 +444,10 @@ public class CustomParticleType implements CustomParticleFactory {
         }
 
         @Override
-        public ParticleRenderType getRenderType() {
-            return this.model == null ? type.renderType.getParticle() : ParticleRenderType.CUSTOM;
+        protected Layer getLayer() {
+            return this.model == null ? type.renderType.getLayer() : CustomParticleType.CUSTOM_LAYER;
         }
+
 
     }
 
@@ -461,14 +472,12 @@ public class CustomParticleType implements CustomParticleFactory {
             };
         }
 
-        public ParticleRenderType getParticle() {
+        public SingleQuadParticle.Layer getLayer() {
             return switch (this) {
-                case TERRAIN -> ParticleRenderType.TERRAIN_SHEET;
-                case TRANSLUCENT -> ParticleRenderType.PARTICLE_SHEET_TRANSLUCENT;
-                case LIT -> ParticleRenderType.TERRAIN_SHEET;
-                case ADDITIVE_TRANSLUCENT -> PolytoneRenderTypes.PARTICLE_ADDITIVE_TRANSLUCENCY_RENDER_TYPE.get();
-                case INVISIBLE -> ParticleRenderType.NO_RENDER;
-                default -> ParticleRenderType.PARTICLE_SHEET_OPAQUE;
+                case TERRAIN, LIT -> SingleQuadParticle.Layer.TERRAIN;
+                case TRANSLUCENT, INVISIBLE -> SingleQuadParticle.Layer.TRANSLUCENT;
+                case ADDITIVE_TRANSLUCENT -> CustomParticleType.ADDITIVE_TRANSLUCENT;
+                default -> SingleQuadParticle.Layer.OPAQUE;
             };
         }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticlesManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/CustomParticlesManager.java
@@ -16,11 +16,13 @@ import net.mehvahdjukaar.polytone.utils.Parsed;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.ParticleResources;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.util.HashMap;
@@ -45,7 +47,8 @@ public class CustomParticlesManager extends JsonPartialReloader {
 
     //just gathers the custom models if any are there
     @Override
-    public void earlyProcess(ResourceManager resourceManager) {
+    public void earlyProcess(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
         for (var j : jsons.entrySet()) {
             var json = j.getValue();
@@ -76,14 +79,15 @@ public class CustomParticlesManager extends JsonPartialReloader {
 
     // not ideal
     public void addSpriteSets(ResourceManager resourceManager) {
-        ParticleEngine engine = Minecraft.getInstance().particleEngine;
+        ParticleResources resources = Minecraft.getInstance().particleEngine.resourceManager;
         for (var v : customParticleFactories.keySet()) {
             //never remove them as it could crash with old already spawner particles. not ideal
-            //engine.spriteSets.remove(v);
+            //resources.spriteSets.remove(v);
         }
         var jsons = this.getJsonsInDirectories(resourceManager);
         for (var v : jsons.keySet()) {
-            engine.spriteSets.put(v, new ParticleEngine.MutableSpriteSet());
+
+            resources.spriteSets.put(v, new ParticleResources.MutableSpriteSet());
         }
     }
 
@@ -95,7 +99,7 @@ public class CustomParticlesManager extends JsonPartialReloader {
     @Override
     protected void parseWithLevel(Map<ResourceLocation, JsonElement> jsons, RegistryOps<JsonElement> ops,
                                   HolderLookup.Provider access) {
-        ParticleEngine particleEngine = Minecraft.getInstance().particleEngine;
+        ParticleResources particleResources = Minecraft.getInstance().particleEngine.resourceManager;
 
         Set<CustomParticleType> customTypes = new HashSet<>();
 
@@ -104,7 +108,7 @@ public class CustomParticlesManager extends JsonPartialReloader {
             try {
                 var factory = j.getValue();
                 var id = j.getKey();
-                factory.setSpriteSet(Minecraft.getInstance().particleEngine.spriteSets.get(id));
+                factory.setSpriteSet(particleResources.spriteSets.get(id));
 
                 if (factory instanceof CustomParticleType c) {
                     customTypes.add(c);
@@ -117,7 +121,7 @@ public class CustomParticlesManager extends JsonPartialReloader {
                     overwrittenVanillaProviders.put(oldType, oldFactory);
                     //override vanilla particle
                     try {
-                        particleEngine.register(oldType, new OverridingParticleFactory<>(factory));
+                        particleResources.register(oldType, new OverridingParticleFactory<>(factory));
                     } catch (Exception e) {
                         Polytone.LOGGER.error("Can't override existing particle with ID {}. Particle type not supported", id, e);
                     }
@@ -139,7 +143,7 @@ public class CustomParticlesManager extends JsonPartialReloader {
             var id = c.getKey();
             ParticleType<ExtraDataParticleOptions> type = PlatStuff.makeParticleType(factory.forceSpawns());
             PlatStuff.registerDynamic(BuiltInRegistries.PARTICLE_TYPE, id, type);
-            particleEngine.register(type, factory);
+            particleResources.register(type, factory);
         }
 
         //initialize recursive stuff

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/ExtraDataParticleOptions.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/ExtraDataParticleOptions.java
@@ -42,7 +42,7 @@ public record ExtraDataParticleOptions(Map<String, Float> extraData,
         return type;
     }
 
-    public void apply(Particle particle) {
+    public void apply(SingleQuadParticle particle) {
         if (extraData.isEmpty()) return;
         Float rot = extraData.get("roll");
         if (rot != null) {

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/OverridingParticleFactory.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/OverridingParticleFactory.java
@@ -5,6 +5,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -18,11 +19,11 @@ public class OverridingParticleFactory<T extends ParticleOptions> implements Par
     }
 
     @Override
-    public @Nullable Particle createParticle(T type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
+    public @Nullable Particle createParticle(T type, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, RandomSource random) {
         try {
             //no server override and this particle already exists so we cant use custom data here.
             var opt = new ExtraDataParticleOptions(Map.of(), type.getType());
-            return customFactory.createParticle(opt, level, x, y, z, xSpeed, ySpeed, zSpeed);
+            return customFactory.createParticle(opt, level, x, y, z, xSpeed, ySpeed, zSpeed, random);
         } catch (Exception e) {
             Polytone.LOGGER.error("Failed to create particle", e);
             return null;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleContextExpression.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleContextExpression.java
@@ -49,7 +49,7 @@ public class ParticleContextExpression extends PolytoneExpression {
 
     private final boolean hasCustom;
 
-    public ParticleContextExpression(String expression){
+    public ParticleContextExpression(String expression) {
         this(expression, false);
     }
 
@@ -78,16 +78,19 @@ public class ParticleContextExpression extends PolytoneExpression {
     public double getValue(Particle particle, Level level) {
         IExpression.IVars vb = expression.varBuilder();
         vb.setVariable(LIFE, particle.getLifetime());
+        if (particle instanceof SingleQuadParticle sqp) {
 
-        int pack = ColorUtils.pack(particle.rCol, particle.gCol, particle.bCol);
-        vb.setVariable(COLOR, pack);
+            int pack = ColorUtils.pack(sqp.rCol, sqp.gCol, sqp.bCol);
+            vb.setVariable(COLOR, pack);
 
-        vb.setVariable(RED, particle.rCol);
-        vb.setVariable(GREEN, particle.gCol);
-        vb.setVariable(BLUE, particle.bCol);
+            vb.setVariable(RED, sqp.rCol);
+            vb.setVariable(GREEN, sqp.gCol);
+            vb.setVariable(BLUE, sqp.bCol);
+            vb.setVariable(ALPHA, sqp.alpha);
+            vb.setVariable(SIZE, sqp.quadSize);
+            vb.setVariable(ROLL, sqp.roll);
+        }
         vb.setVariable(SPEED, Mth.length(particle.xd, particle.yd, particle.zd));
-        vb.setVariable(ALPHA, particle.alpha);
-        vb.setVariable(SIZE, ((SingleQuadParticle) particle).quadSize);
         vb.setVariable(DX, particle.xd);
         vb.setVariable(DY, particle.yd);
         vb.setVariable(DZ, particle.zd);
@@ -95,7 +98,6 @@ public class ParticleContextExpression extends PolytoneExpression {
         vb.setVariable(Y, particle.y);
         vb.setVariable(Z, particle.z);
         vb.setVariable(AGE, particle.age);
-        vb.setVariable(ROLL, particle.roll);
         if (hasCustom && particle instanceof CustomParticleType.Instance i)
             vb.setVariable(CUSTOM, i.getCustom());
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleModifier.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleModifier.java
@@ -10,6 +10,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.mehvahdjukaar.polytone.utils.Targets;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.SingleQuadParticle;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ItemParticleOption;
@@ -116,7 +117,7 @@ public class ParticleModifier {
         return this.targets;
     }
 
-    public void modify(@NotNull Particle particle, Level level, ParticleOptions options) {
+    public void modify(@NotNull SingleQuadParticle particle, Level level, ParticleOptions options) {
         if (filter != null) {
             if (!filter.test(options)) return;
         }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleModifiersManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleModifiersManager.java
@@ -13,6 +13,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.gui.screens.social.PlayerEntry;
 import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.SingleQuadParticle;
 import net.minecraft.core.BlockPos;
 import net.minecraft.client.particle.TotemParticle;
 import net.minecraft.core.RegistryAccess;
@@ -49,9 +50,11 @@ public class ParticleModifiersManager extends JsonImgPartialReloader {
     }
 
     public void maybeModify(ParticleOptions options, Level level, @NotNull Particle particle) {
-        var mod = particleModifiers.get(options.getType());
-        for (var modifier : mod) {
-            modifier.modify(particle, level, options);
+        if (particle instanceof SingleQuadParticle sqp) {
+            var mod = particleModifiers.get(options.getType());
+            for (var modifier : mod) {
+                modifier.modify(sqp, level, options);
+            }
         }
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/SemiCustomParticleType.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/SemiCustomParticleType.java
@@ -8,15 +8,13 @@ import net.mehvahdjukaar.polytone.colormap.Colormap;
 import net.mehvahdjukaar.polytone.colormap.IColorGetter;
 import net.mehvahdjukaar.polytone.utils.ColorUtils;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.particle.Particle;
-import net.minecraft.client.particle.ParticleEngine;
-import net.minecraft.client.particle.ParticleProvider;
-import net.minecraft.client.particle.SingleQuadParticle;
+import net.minecraft.client.particle.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
@@ -30,7 +28,7 @@ public class SemiCustomParticleType implements CustomParticleFactory {
     private final ParticleType<?> copyType;
     private ParticleProvider<?> copyProvider = null;
     private boolean hasBeenInit = false;
-    private ParticleEngine.MutableSpriteSet spriteSet = null;
+    private SpriteSet spriteSet = null;
     private final @Nullable ParticleInitializer initializer;
     private final boolean hasPhysics;
     private final @Nullable IColorGetter colormap;
@@ -56,35 +54,34 @@ public class SemiCustomParticleType implements CustomParticleFactory {
     }
 
     @Override
-    public void setSpriteSet(ParticleEngine.MutableSpriteSet mutableSpriteSet) {
-        this.spriteSet = mutableSpriteSet;
+    public void setSpriteSet(SpriteSet spriteSet) {
+        this.spriteSet = spriteSet;
     }
 
     @Override
-    public Particle createParticle(ExtraDataParticleOptions opt, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
-                                   @Nullable BlockState state) {
+    public Particle createParticleWithState(ExtraDataParticleOptions opt, ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed,
+                                   @Nullable BlockState state, RandomSource random) {
         if (!hasBeenInit) {
             init();
         }
 
         if (copyProvider != null) {
-            var particle = ((ParticleProvider) copyProvider).createParticle(((ParticleOptions) copyType), level, x, y, z, xSpeed, ySpeed, zSpeed);
+            var particle = ((ParticleProvider) copyProvider).createParticle(((ParticleOptions) copyType), level, x, y, z, xSpeed, ySpeed, zSpeed, random);
 
             BlockPos pos = BlockPos.containing(x, y, z);
 
             //initialize
-            if (initializer != null && particle instanceof SingleQuadParticle sp) {
-                initializer.initialize(sp, level, state, pos);
+            if (initializer != null && particle instanceof SingleQuadParticle sqp) {
+                initializer.initialize(sqp, level, state, pos);
+                opt.apply(sqp);
             }
-
-            opt.apply(particle);
 
             if (particle != null) {
                 particle.hasPhysics = this.hasPhysics;
 
-                if (this.colormap != null) {
+                if (this.colormap != null && particle instanceof SingleQuadParticle sqp) {
                     float[] unpack = ColorUtils.unpack(this.colormap.getColor(state, level, pos, 0));
-                    particle.setColor(unpack[0], unpack[1], unpack[2]);
+                    sqp.setColor(unpack[0], unpack[1], unpack[2]);
                 }
 
                 if (this.hasPhysics) {

--- a/common/src/main/java/net/mehvahdjukaar/polytone/server/ServerReloadListener.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/server/ServerReloadListener.java
@@ -35,7 +35,7 @@ public abstract class ServerReloadListener extends PartialReloader implements Pr
     }
 
     @Override
-    protected Object prepare(ResourceManager resourceManager) {
+    protected Object prepare(PreparableReloadListener.SharedState sharedState) {
         return null;
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/slotify/BlitModifier.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/slotify/BlitModifier.java
@@ -9,7 +9,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
@@ -52,7 +55,8 @@ public record BlitModifier(ResourceLocation target, int index, int xInc, int yIn
         }
 
         if (newTexture.isPresent()) {
-            sprite = Minecraft.getInstance().getGuiSprites().getSprite(newTexture.get());
+            var material = new Material(Sheets.GUI_SHEET, newTexture.get());
+            sprite = gui.getSprite(material);
         }
         float minU = u0 == -1 ? oldU0 : u0;
         float maxU = u1 == -1 ? oldU1 : u1;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/slotify/GuiOverlayManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/slotify/GuiOverlayManager.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.pipeline.RenderPipeline;
 import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.utils.JsonPartialReloader;
 import net.mehvahdjukaar.polytone.utils.Parsed;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.RenderPipelines;
@@ -12,6 +13,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.util.EnumMap;
@@ -54,9 +56,10 @@ public class GuiOverlayManager extends JsonPartialReloader {
     }
 
     @Override
-    protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager) {
+    protected Map<ResourceLocation, JsonElement> prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         reloadHearths(resourceManager);
-        return super.prepare(resourceManager);
+        return super.prepare(sharedState);
     }
 
     private int index = 0;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/slotify/RelativeSprite.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/slotify/RelativeSprite.java
@@ -6,7 +6,9 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.mehvahdjukaar.polytone.utils.GuiDepthTarget;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.Optional;
@@ -37,7 +39,8 @@ public record RelativeSprite(ResourceLocation texture, int x, int y, Optional<Gu
         y1 += y;
         oldh += height;
         y2 = y1 + oldh;
-        TextureAtlasSprite sprite = Minecraft.getInstance().getGuiSprites().getSprite(texture);
+        var material = new Material(Sheets.GUI_SHEET, texture);
+        TextureAtlasSprite sprite = graphics.getSprite(material);
 
         int finalX = x1;
         int finalX1 = x2;

--- a/common/src/main/java/net/mehvahdjukaar/polytone/slotify/SimpleSprite.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/slotify/SimpleSprite.java
@@ -6,7 +6,9 @@ import net.mehvahdjukaar.polytone.utils.GuiDepthTarget;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.Optional;
@@ -30,7 +32,8 @@ public record SimpleSprite(ResourceLocation texture, int x, int y, int width, in
 
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        TextureAtlasSprite sprite = Minecraft.getInstance().getGuiSprites().getSprite(texture);
+        var material = new Material(Sheets.GUI_SHEET, texture);
+        TextureAtlasSprite sprite = guiGraphics.getSprite(material);
         Runnable render = () -> {
             guiGraphics.blit(texture,
                     x, x + width, y, y + height,

--- a/common/src/main/java/net/mehvahdjukaar/polytone/sound/SoundTypesManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/sound/SoundTypesManager.java
@@ -13,6 +13,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.level.block.SoundType;
@@ -37,7 +38,8 @@ public class SoundTypesManager extends PartialReloader<SoundTypesManager.Resourc
     }
 
     @Override
-    protected Resources prepare(ResourceManager resourceManager) {
+    protected Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = getJsonsInDirectories(resourceManager);
 
         var types = CsvUtils.parseCsv(resourceManager, "sound_events");

--- a/common/src/main/java/net/mehvahdjukaar/polytone/tabs/CreativeTabsModifiersManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/tabs/CreativeTabsModifiersManager.java
@@ -8,6 +8,7 @@ import net.mehvahdjukaar.polytone.utils.CsvUtils;
 import net.mehvahdjukaar.polytone.utils.MapRegistry;
 import net.mehvahdjukaar.polytone.utils.Parsed;
 import net.mehvahdjukaar.polytone.utils.PartialReloader;
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -15,6 +16,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
@@ -36,7 +38,8 @@ public class CreativeTabsModifiersManager extends PartialReloader<CreativeTabsMo
 
 
     @Override
-    public Resources prepare(ResourceManager resourceManager) {
+    public Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = getJsonsInDirectories(resourceManager);
 
         var types = CsvUtils.parseCsv(resourceManager, "creative_tabs");

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/CompoundReloader.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/CompoundReloader.java
@@ -10,7 +10,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
-import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.Level;
 
@@ -32,9 +31,9 @@ public class CompoundReloader implements PreparableReloadListener {
     }
 
     @Override
-    public CompletableFuture<Void> reload(PreparationBarrier preparationBarrier, ResourceManager resourceManager, Executor backgroundExecutor, Executor gameExecutor) {
+    public CompletableFuture<Void> reload(SharedState sharedState, Executor backgroundExecutor, PreparationBarrier preparationBarrier,  Executor gameExecutor) {
         List<CompletableFuture<?>> futures = children.stream()
-                .map(child -> CompletableFuture.supplyAsync(() -> child.prepare(resourceManager), backgroundExecutor))
+                .map(child -> CompletableFuture.supplyAsync(() -> child.prepare(sharedState), backgroundExecutor))
                 .collect(Collectors.toList());
 
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
@@ -121,9 +120,9 @@ public class CompoundReloader implements PreparableReloadListener {
         }
     }
 
-    public void earlyProcess(ResourceManager resourceManager) {
+    public void earlyProcess(SharedState sharedState) {
         for (var c : children) {
-            c.earlyProcess(resourceManager);
+            c.earlyProcess(sharedState);
         }
         PlatStuff.doAddModels();
     }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/JsonImgPartialReloader.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/JsonImgPartialReloader.java
@@ -2,7 +2,9 @@ package net.mehvahdjukaar.polytone.utils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.util.Map;
@@ -14,7 +16,8 @@ public abstract class JsonImgPartialReloader extends PartialReloader<JsonImgPart
     }
 
     @Override
-    protected Resources prepare(ResourceManager resourceManager) {
+    protected Resources prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
         var textures = this.getImagesInDirectories(resourceManager);
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/JsonPartialReloader.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/JsonPartialReloader.java
@@ -2,7 +2,9 @@ package net.mehvahdjukaar.polytone.utils;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.util.Map;
@@ -14,7 +16,8 @@ public abstract class JsonPartialReloader extends PartialReloader<Map<ResourceLo
     }
 
     @Override
-    protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager) {
+    protected Map<ResourceLocation, JsonElement> prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         var jsons = this.getJsonsInDirectories(resourceManager);
         return ImmutableMap.copyOf(jsons);
     }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/Parsed.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/Parsed.java
@@ -86,7 +86,7 @@ public class Parsed<T> {
         if (ignore) {
             return false;
         }
-        if (version.isPresent() && !version.get().matches(SharedConstants.VERSION_STRING)) {
+        if (version.isPresent() && !version.get().matches(SharedConstants.getCurrentVersion().id())) {
             return false;
         }
         for (String s : modList) {

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/PartialReloader.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/PartialReloader.java
@@ -8,6 +8,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.GsonHelper;
@@ -101,11 +102,11 @@ public abstract class PartialReloader<T> {
         return ArrayImage.groupTextures(this.getImagesInDirectories(manager));
     }
 
-    protected void earlyProcess(ResourceManager resourceManager) {
+    protected void earlyProcess(PreparableReloadListener.SharedState sharedState) {
 
     }
 
-    protected abstract T prepare(ResourceManager resourceManager);
+    protected abstract T prepare(PreparableReloadListener.SharedState sharedState);
 
     protected abstract void parseWithLevel(T obj, RegistryOps<JsonElement> ops, HolderLookup.Provider access);
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/SingleJsonOrPropertiesReloadListener.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/SingleJsonOrPropertiesReloadListener.java
@@ -6,7 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.mehvahdjukaar.polytone.Polytone;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.GsonHelper;
 
@@ -33,7 +35,8 @@ public abstract class SingleJsonOrPropertiesReloadListener extends PartialReload
     }
 
     @Override
-    protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager) {
+    protected Map<ResourceLocation, JsonElement> prepare(PreparableReloadListener.SharedState sharedState) {
+        var resourceManager = sharedState.resourceManager();
         Map<ResourceLocation, JsonElement> jsonObjects = new HashMap<>();
         for (String path : folders) {
 

--- a/common/src/main/resources/polytone-common.mixins.json
+++ b/common/src/main/resources/polytone-common.mixins.json
@@ -28,6 +28,7 @@
     "ModelBlockRendererMixin",
     "ModelManagerMixin",
     "ParticleEngineMixin",
+    "ParticleResourcesMixin",
     "ScreenMixin",
     "SmithingScreenMixin",
     "SodiumBlockRendererMixin",
@@ -36,7 +37,7 @@
     "XpOrbMixin",
     "accessor.BiomeAccessor",
     "accessor.DustParticleOptionAccessor",
-    "accessor.ParticleAccessor"
+    "accessor.ParticleAccessor",
   ],
   "injectors": {
     "defaultRequire": 1

--- a/common/src/main/resources/polytone.accesswidener
+++ b/common/src/main/resources/polytone.accesswidener
@@ -11,7 +11,6 @@ mutable field net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBas
 
 accessible field net/minecraft/client/renderer/RenderPipelines TERRAIN_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
 accessible field net/minecraft/client/renderer/RenderStateShard BLOCK_SHEET_MIPPED Lnet/minecraft/client/renderer/RenderStateShard$TextureStateShard;
-accessible field net/minecraft/client/renderer/RenderStateShard PARTICLES_TARGET Lnet/minecraft/client/renderer/RenderStateShard$OutputStateShard;
 accessible method net/minecraft/client/renderer/RenderType$CompositeState$CompositeStateBuilder setOutputState (Lnet/minecraft/client/renderer/RenderStateShard$OutputStateShard;)Lnet/minecraft/client/renderer/RenderType$CompositeState$CompositeStateBuilder;
 
 accessible field net/minecraft/client/renderer/RenderPipelines MATRICES_FOG_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;
@@ -27,8 +26,14 @@ mutable field net/minecraft/world/entity/player/Player inventoryMenu Lnet/minecr
 #particle clear
 accessible field net/minecraft/client/particle/ParticleEngine particles Ljava/util/Map;
 
+
 accessible field net/minecraft/client/particle/Particle friction F
-accessible field net/minecraft/client/particle/Particle oRoll F
+accessible field net/minecraft/client/particle/SingleQuadParticle alpha F
+accessible field net/minecraft/client/particle/SingleQuadParticle roll F
+accessible field net/minecraft/client/particle/SingleQuadParticle oRoll F
+accessible field net/minecraft/client/particle/SingleQuadParticle bCol F
+accessible field net/minecraft/client/particle/SingleQuadParticle gCol F
+accessible field net/minecraft/client/particle/SingleQuadParticle rCol F
 accessible field net/minecraft/client/particle/Particle hasPhysics Z
 
 
@@ -60,12 +65,13 @@ mutable field net/minecraft/world/level/block/ButtonBlock type Lnet/minecraft/wo
 accessible field net/minecraft/world/level/block/BasePressurePlateBlock type Lnet/minecraft/world/level/block/state/properties/BlockSetType;
 mutable field net/minecraft/world/level/block/BasePressurePlateBlock type Lnet/minecraft/world/level/block/state/properties/BlockSetType;
 
-accessible field net/minecraft/client/particle/ParticleEngine spriteSets Ljava/util/Map;
-accessible class net/minecraft/client/particle/ParticleEngine$MutableSpriteSet
-accessible method net/minecraft/client/particle/ParticleEngine$MutableSpriteSet <init> ()V
+accessible field net/minecraft/client/Minecraft particleResources Lnet/minecraft/client/particle/ParticleResources;
+accessible field net/minecraft/client/particle/ParticleEngine resourceManager Lnet/minecraft/client/particle/ParticleResources;
+accessible field net/minecraft/client/particle/ParticleResources spriteSets Ljava/util/Map;
+accessible class net/minecraft/client/particle/ParticleResources$MutableSpriteSet
+accessible method net/minecraft/client/particle/ParticleResources$MutableSpriteSet <init> ()V
 accessible field net/minecraft/client/particle/Particle age I
 accessible field net/minecraft/client/particle/SingleQuadParticle quadSize F
-accessible field net/minecraft/client/particle/Particle roll F
 
 accessible field net/minecraft/world/level/border/BorderStatus color I
 mutable field net/minecraft/world/level/border/BorderStatus color I
@@ -116,11 +122,6 @@ accessible field net/minecraft/client/particle/Particle z D
 mutable field net/minecraft/world/inventory/Slot x I
 mutable field net/minecraft/world/inventory/Slot y I
 
-accessible field net/minecraft/client/particle/Particle rCol F
-accessible field net/minecraft/client/particle/Particle gCol F
-accessible field net/minecraft/client/particle/Particle bCol F
-accessible field net/minecraft/client/particle/Particle alpha F
-
 accessible field net/minecraft/world/effect/MobEffect color I
 mutable field net/minecraft/world/effect/MobEffect color I
 
@@ -164,14 +165,13 @@ accessible field net/minecraft/core/MappedRegistry registrationInfos Ljava/util/
 accessible field net/minecraft/core/MappedRegistry frozen Z
 
 
-accessible method net/minecraft/client/particle/ParticleEngine register (Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V
-
+accessible method net/minecraft/client/particle/ParticleResources register (Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V
 accessible method net/minecraft/world/level/biome/Biome getTemperature (Lnet/minecraft/core/BlockPos;I)F
 
 accessible field net/minecraft/client/renderer/DimensionSpecialEffects skyType Lnet/minecraft/client/renderer/DimensionSpecialEffects$SkyType;
 mutable field net/minecraft/client/renderer/DimensionSpecialEffects skyType Lnet/minecraft/client/renderer/DimensionSpecialEffects$SkyType;
-accessible field net/minecraft/client/renderer/DimensionSpecialEffects forceBrightLightmap Z
-mutable field net/minecraft/client/renderer/DimensionSpecialEffects forceBrightLightmap Z
+accessible field net/minecraft/client/renderer/DimensionSpecialEffects hasEndFlashes Z
+mutable field net/minecraft/client/renderer/DimensionSpecialEffects hasEndFlashes Z
 accessible field net/minecraft/client/renderer/DimensionSpecialEffects constantAmbientLight Z
 mutable field net/minecraft/client/renderer/DimensionSpecialEffects constantAmbientLight Z
 
@@ -179,6 +179,8 @@ accessible method net/minecraft/client/gui/GuiGraphics innerBlit (Lcom/mojang/bl
 accessible class net/minecraft/client/gui/render/state/GuiRenderState$Node
 accessible method net/minecraft/client/gui/render/state/GuiRenderState$Node <init> (Lnet/minecraft/client/gui/render/state/GuiRenderState$Node;)V
 accessible method net/minecraft/client/renderer/fog/FogRenderer computeFogColor (Lnet/minecraft/client/Camera;FLnet/minecraft/client/multiplayer/ClientLevel;IFZ)Lorg/joml/Vector4f;
+accessible field net/minecraft/client/renderer/fog/FogRenderer FOG_ENVIRONMENTS Ljava/util/List;
+accessible field net/minecraft/client/renderer/GameRenderer fogRenderer Lnet/minecraft/client/renderer/fog/FogRenderer;
 
 accessible field net/minecraft/world/item/alchemy/PotionContents BASE_POTION_COLOR I
 mutable field net/minecraft/world/item/alchemy/PotionContents BASE_POTION_COLOR I

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PlatStuffImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PlatStuffImpl.java
@@ -4,7 +4,6 @@ import com.google.common.base.Suppliers;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorResolverRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.DimensionRenderingRegistry;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroupEntries;
@@ -26,22 +25,18 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.SessionSearchTrees;
-import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleProvider;
-import net.minecraft.client.renderer.DimensionSpecialEffects;
+import net.minecraft.client.particle.ParticleResources;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.particles.ParticleType;
-import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
-import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.ItemStack;
@@ -76,8 +71,8 @@ public class PlatStuffImpl {
                 return name;
             }
 
-            public CompletableFuture<Void> reload(PreparationBarrier preparationBarrier, ResourceManager resourceManager, Executor executor, Executor executor2) {
-                return this.inner.get().reload(preparationBarrier, resourceManager, executor, executor2);
+            public CompletableFuture<Void> reload(SharedState sharedState,Executor backgroundExecutor, PreparationBarrier preparationBarrier,  Executor executor2) {
+                return this.inner.get().reload(sharedState, backgroundExecutor, preparationBarrier, executor2);
             }
         });
     }
@@ -95,9 +90,9 @@ public class PlatStuffImpl {
         return FabricLoader.getInstance().isModLoaded(namespace);
     }
 
-    public static DimensionSpecialEffects getDimensionEffects(ResourceLocation id) {
-        return DimensionRenderingRegistry.getDimensionEffects(id);
-    }
+//    public static DimensionSpecialEffects getDimensionEffects(ResourceLocation id) {
+//        return DimensionRenderingRegistry.getDimensionEffects(id);
+//    }
 
     public static void applyBiomeSurgery(Biome biome, BiomeSpecialEffects newEffects) {
         try {
@@ -239,12 +234,12 @@ public class PlatStuffImpl {
     }
 
     public static ParticleProvider<?> getParticleProvider(ParticleType<?> type) {
-        return ((ParticleEngineAccessor) Minecraft.getInstance().particleEngine)
+        return ((ParticleResourcesAccessor) Minecraft.getInstance().particleResources)
                 .getProviders().get(BuiltInRegistries.PARTICLE_TYPE.getId(type));
     }
 
     public static void setParticleProvider(ParticleType<?> type, ParticleProvider<?> provider) {
-        ((ParticleEngineAccessor) Minecraft.getInstance().particleEngine)
+        ((ParticleResourcesAccessor) Minecraft.getInstance().particleResources)
                 .getProviders().put(BuiltInRegistries.PARTICLE_TYPE.getId(type), provider);
     }
 
@@ -259,8 +254,8 @@ public class PlatStuffImpl {
 
     public static void unregisterParticleProvider(ResourceLocation id) {
         var type = BuiltInRegistries.PARTICLE_TYPE.get(id);
-        ParticleEngine particleEngine = Minecraft.getInstance().particleEngine;
-        ((ParticleEngineAccessor) particleEngine)
+        ParticleResources particleResources = Minecraft.getInstance().particleResources;
+        ((ParticleResourcesAccessor) particleResources)
                 .getProviders().remove(BuiltInRegistries.PARTICLE_TYPE.getId(type.get().value()));
     }
 

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PolytoneFabric.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PolytoneFabric.java
@@ -4,7 +4,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.CommonLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -36,7 +36,7 @@ public class PolytoneFabric implements ClientModInitializer {
                 Polytone.onTagsReceived(registries);
             }
         });
-        WorldRenderEvents.START.register((context) ->
+        WorldRenderEvents.START_MAIN.register((context) ->
                 ClientFrameTicker.onRenderTick(context.gameRenderer().getMinecraft()));
 
         ClientTickEvents.START_CLIENT_TICK.register((client) -> {

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/AbstractContainerScreenMixin.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/AbstractContainerScreenMixin.java
@@ -69,24 +69,24 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
         }
     }
 
-    @ModifyArg(method = "renderLabels",
-            index = 4,
-            require = 1,
-            at = @At(value = "INVOKE",
-                    ordinal = 0,
-                    target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIZ)I"))
+//    @ModifyArg(method = "renderLabels",
+//            index = 4,
+//            require = 1,
+//            at = @At(value = "INVOKE",
+//                    ordinal = 0,
+//                    target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIZ)I"))
     private int changeTitleColor(int fontColor) {
         if (polytone$customTitleColor != null) return polytone$customTitleColor;
         return fontColor;
     }
 
 
-    @ModifyArg(method = "renderLabels",
-            index = 4,
-            require = 1,
-            at = @At(value = "INVOKE",
-                    ordinal = 1,
-                    target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIZ)I"))
+//    @ModifyArg(method = "renderLabels",
+//            index = 4,
+//            require = 1,
+//            at = @At(value = "INVOKE",
+//                    ordinal = 1,
+//                    target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIZ)I"))
     private int changeLabelColor(int fontColor) {
         if (polytone$customLabelColor != null) return polytone$customLabelColor;
         return fontColor;

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/FogFluidRendererMixin.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/FogFluidRendererMixin.java
@@ -1,6 +1,5 @@
 package net.mehvahdjukaar.polytone.mixins.fabric;
 
-import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.mehvahdjukaar.polytone.Polytone;
 import net.mehvahdjukaar.polytone.fluid.FluidPropertyModifier;
@@ -8,7 +7,7 @@ import net.mehvahdjukaar.polytone.utils.ColorUtils;
 import net.minecraft.client.Camera;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.client.renderer.fog.FogRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.material.FluidState;
 import org.joml.Vector4f;
@@ -22,18 +21,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(FogRenderer.class)
 public abstract class FogFluidRendererMixin {
     @Inject(method = "computeFogColor", at = @At(value = "TAIL"), cancellable = true)
-    private static void polytone$modifyFluidFogColor(Camera camera, float f, ClientLevel level, int i, float g, CallbackInfoReturnable<Vector4f> cir) {
+    private static void polytone$modifyFluidFogColor(Camera camera, float f, ClientLevel clientLevel, int i, float g, boolean bl, CallbackInfoReturnable<Vector4f> cir) {
         // Modify fog color depending on the fluid
         Vector4f output = cir.getReturnValue();
         BlockPos pos = camera.getBlockPosition();
-        FluidState state = level.getFluidState(pos);
+        FluidState state = clientLevel.getFluidState(pos);
         if (camera.getPosition().y < (double) ((float) pos.getY() +
-                state.getHeight(level, pos))) {
+                state.getHeight(clientLevel, pos))) {
             FluidPropertyModifier modifier = Polytone.FLUID_MODIFIERS.getModifier(state.getType());
             if (modifier != null) {
                 BlockColor col = modifier.getFogColormap();
                 if (col != null) {
-                    var newC = ColorUtils.unpack(col.getColor(null, level, pos, -1) | 0xff000000);
+                    var newC = ColorUtils.unpack(col.getColor(null, clientLevel, pos, -1) | 0xff000000);
                     output.set(newC[0], newC[1], newC[2], output.w);
                     cir.setReturnValue(output);
                 }

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/FogRendererMixin2.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/FogRendererMixin2.java
@@ -4,8 +4,13 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.mehvahdjukaar.polytone.Polytone;
 import net.minecraft.client.Camera;
-import net.minecraft.client.renderer.FogParameters;
-import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.fog.FogData;
+import net.minecraft.client.renderer.fog.environment.FogEnvironment;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.material.FogType;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,20 +19,20 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(FogRenderer.class)
+@Mixin(FogEnvironment.class)
 public abstract class FogRendererMixin2 {
-
-    @Inject(method = "setupFog", at = @At(value = "TAIL"), cancellable = true)
-    private static void polytone$modifyFogShape(Camera camera, FogRenderer.FogMode fogMode, Vector4f vector4f, float f, boolean bl, float g, CallbackInfoReturnable<FogParameters> cir, @Local FogType fogType) {
-        if (fogMode == FogRenderer.FogMode.FOG_TERRAIN && fogType == FogType.NONE) {
-            var newFog = Polytone.BIOME_MODIFIERS.modifyFogParameters(
-                    cir.getReturnValue().start(), cir.getReturnValue().end());
-            if (newFog != null) {
-                FogParameters old = cir.getReturnValue();
-                cir.setReturnValue(new FogParameters(newFog.x, newFog.y, old.shape(), old.red(), old.green(), old.blue(), old.alpha()));
-            }
-
-        }
+/* Disable biome fog modification for now */
+//    @Inject(method = "setupFog", at = @At(value = "TAIL"), cancellable = true)
+    private static void polytone$modifyFogShape(FogData par1, Entity par2, BlockPos par3, ClientLevel par4, float par5, DeltaTracker par6, CallbackInfo ci, @Local FogType fogType) {
+//        if (fogMode == FogRenderer.FogMode.FOG_TERRAIN && fogType == FogType.NONE) {
+//            var newFog = Polytone.BIOME_MODIFIERS.modifyFogParameters(
+//                    cir.getReturnValue().start(), cir.getReturnValue().end());
+//            if (newFog != null) {
+//                FogParameters old = cir.getReturnValue();
+//                cir.setReturnValue(new FogParameters(newFog.x, newFog.y, old.shape(), old.red(), old.green(), old.blue(), old.alpha()));
+//            }
+//
+//        }
     }
 
 }

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/ParticleEngineAccessor.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/ParticleEngineAccessor.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.client.particle.ParticleProvider;
 import net.minecraft.client.particle.ParticleRenderType;
+import net.minecraft.client.particle.ParticleResources;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,9 +16,6 @@ import java.util.Map;
 
 @Mixin(ParticleEngine.class)
 public interface ParticleEngineAccessor {
-
-    @Accessor("providers")
-    Int2ObjectMap<ParticleProvider<?>> getProviders();
 
     @Accessor("RENDER_ORDER")
     @Mutable
@@ -31,3 +29,4 @@ public interface ParticleEngineAccessor {
         throw new UnsupportedOperationException();
     }
 }
+

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/ParticleResourcesAccessor.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/mixins/fabric/ParticleResourcesAccessor.java
@@ -1,0 +1,20 @@
+package net.mehvahdjukaar.polytone.mixins.fabric;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.ParticleRenderType;
+import net.minecraft.client.particle.ParticleResources;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(ParticleResources.class)
+public interface ParticleResourcesAccessor {
+
+    @Accessor("providers")
+    Int2ObjectMap<ParticleProvider<?>> getProviders();
+
+}

--- a/fabric/src/main/resources/polytone.mixins.json
+++ b/fabric/src/main/resources/polytone.mixins.json
@@ -21,6 +21,7 @@
     "ItemBlockRenderTypeAccessor",
     "ModelBlockRendererMixin",
     "ParticleEngineAccessor",
+    "ParticleResourcesAccessor",
     "RegistrySyncManagerMixin"
   ],
   "injectors": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,9 @@ org.gradle.daemon = false
 
 
 # Mc stuff
-minecraft_version = 1.21.7
-minecraft_min_version = 1.21.6
-minecraft_max_version = 1.21.7
+minecraft_version = 1.21.10
+minecraft_min_version = 1.21.9
+minecraft_max_version = 1.21.11
 
 enabled_platforms = fabric,neoforge
 pack_format_number = 20
@@ -21,7 +21,7 @@ pack_format_number = 20
 # Mod stuff
 mod_id = polytone
 mod_name = Polytone
-mod_version = 1.21.7-3.5.1
+mod_version = 1.21.10-3.5.1
 mod_license = Supplementaries Team License v.1.1
 mod_group_id = net.mehvahdjukaar
 mod_authors = MehVahdJukaar
@@ -41,13 +41,13 @@ exp4j_version = 0.4.8
 parchment_version = 1.21:2024.07.28
 quilt_version = 1.21+build.2:v2
 
-fabric_loader_version=0.16.14
+fabric_loader_version=0.18.0
 
 # Fabric API
-fabric_api_version=0.128.2+1.21.7
+fabric_api_version=0.138.3+1.21.10
 
-neo_version = 21.7.8-beta
-neo_version_range = [21.5.10-beta,)
+neo_version = 21.10.52-beta
+neo_version_range = [21.10.52-beta,)
 loader_version_range = [4,)
 
 

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/fluid/neoforge/FluidPropertiesManagerImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/fluid/neoforge/FluidPropertiesManagerImpl.java
@@ -10,8 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.FogParameters;
-import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.client.renderer.fog.FogRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -121,10 +120,10 @@ public class FluidPropertiesManagerImpl {
             return existingProperties.modifyFogColor(camera, partialTick, level, renderDistance, darkenWorldAmount, fluidFogColor);
         }
 
-        @Override
-        public FogParameters modifyFogRender(Camera camera, FogRenderer.FogMode mode, float renderDistance, float partialTick, FogParameters fogParameters) {
-            return existingProperties.modifyFogRender(camera, mode, renderDistance, partialTick, fogParameters);
-        }
+//        @Override
+//        public FogParameters modifyFogRender(Camera camera, FogRenderer.FogMode mode, float renderDistance, float partialTick, FogParameters fogParameters) {
+//            return existingProperties.modifyFogRender(camera, mode, renderDistance, partialTick, fogParameters);
+//        }
 
         @Override
         public ResourceLocation getStillTexture(FluidState state, BlockAndTintGetter getter, BlockPos pos) {

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/AlexsCavesCompat.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/AlexsCavesCompat.java
@@ -18,7 +18,7 @@ public class AlexsCavesCompat {
     }
 
     public static void applyACLightingColors(ClientLevel level, Vector3f combined, float partialTicks) {
-        if (!level.effects().forceBrightLightmap()) {
+        if (!level.effects().hasEndFlashes()) {
             Vec3 in = new Vec3(combined);
             Vec3 to = ClientProxy.lastBiomeLightColorPrev.add(ClientProxy.lastBiomeLightColor.subtract(ClientProxy.lastBiomeLightColorPrev).scale(partialTicks));
             combined.set(to.x * in.x, to.y * in.y, to.z * in.z);

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/ModelStuffImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/ModelStuffImpl.java
@@ -2,13 +2,14 @@ package net.mehvahdjukaar.polytone.neoforge;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.fog.environment.FogEnvironment;
+import net.minecraft.client.resources.model.ModelDebugName;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.resources.model.QuadCollection;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.client.event.ModelEvent;
-import net.neoforged.neoforge.client.model.standalone.StandaloneModelBaker;
+import net.neoforged.neoforge.client.model.standalone.SimpleUnbakedStandaloneModel;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,8 +26,13 @@ public class ModelStuffImpl {
     }
 
     public static void addSpecialModel(ResourceLocation id) {
-        SPECIAL_MODELS.put(id, new StandaloneModelKey<>(id));
-        FogEnvironment
+        SPECIAL_MODELS.put(id, new StandaloneModelKey<>(new ModelDebugName() {
+            @Override
+            public String debugName() {
+                return id.toString();
+            }
+        }));
+
     }
 
     @Nullable
@@ -39,13 +45,13 @@ public class ModelStuffImpl {
         return null;
     }
 
-    public static void init(IEventBus bus){
+    public static void init(IEventBus bus) {
         bus.addListener(ModelStuffImpl::registerExtraModels);
     }
 
     public static void registerExtraModels(ModelEvent.RegisterStandalone event) {
-        for (var entry : SPECIAL_MODELS.values()) {
-            event.register(entry, StandaloneModelBaker.quadCollection());
+        for (var entry : SPECIAL_MODELS.entrySet()) {
+            event.register(entry.getValue(), SimpleUnbakedStandaloneModel.quadCollection(entry.getKey()));
         }
     }
 }

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PlatStuffImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PlatStuffImpl.java
@@ -46,7 +46,6 @@ import net.neoforged.neoforge.client.CreativeModeTabSearchRegistry;
 import net.neoforged.neoforge.client.DimensionSpecialEffectsManager;
 import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.ModelEvent;
-import net.neoforged.neoforge.client.model.standalone.StandaloneModelBaker;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
 import net.neoforged.neoforge.common.CreativeModeTabRegistry;
 import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
@@ -163,7 +162,7 @@ public class PlatStuffImpl {
     }
 
     public static RegistryAccess hackyGetRegistryAccess() {
-        if (FMLEnvironment.dist == Dist.CLIENT &&
+        if (FMLEnvironment.getDist() == Dist.CLIENT &&
                 RenderSystem.isOnRenderThread()) {
             ClientLevel level = Minecraft.getInstance().level;
             if (level != null) return level.registryAccess();

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PolytoneForge.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PolytoneForge.java
@@ -12,7 +12,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.render.GuiRenderer;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.client.renderer.fog.FogRenderer;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
@@ -56,9 +56,9 @@ public class PolytoneForge {
     public PolytoneForge(IEventBus modBus) {
         bus = modBus;
         ModelStuffImpl.init(bus);
-        if (FMLEnvironment.dist == Dist.CLIENT) {
+        if (FMLEnvironment.getDist() == Dist.CLIENT) {
             boolean iris = ModList.get().isLoaded("iris") || ModList.get().isLoaded("oculus");
-            Polytone.init(!FMLEnvironment.production, true, iris);
+            Polytone.init(!FMLEnvironment.isProduction(), true, iris);
             NeoForge.EVENT_BUS.register(this);
             modBus.addListener(EventPriority.LOWEST, this::modifyCreativeTabs);
         } else {
@@ -116,12 +116,14 @@ public class PolytoneForge {
 
     @SubscribeEvent
     public void fogEvent(ViewportEvent.RenderFog fogEvent) {
-        if (fogEvent.getType() != FogType.NONE || fogEvent.getType() != FogType.TERRAIN) return;
+        // dannyb - this call would always return, since if fogtype is TERRAIN the first part is true (TERRAIN != NONE) , and if fogtype is not TERRAIN (including NONE) the second part is true (all other fogtype != TERRAIN).
+        //        if (fogEvent.getType() != FogType.NONE || fogEvent.getType() != FogType.TERRAIN) return;
         Vec2 targetFog = Polytone.BIOME_MODIFIERS.modifyFogParameters(fogEvent.getNearPlaneDistance(), fogEvent.getFarPlaneDistance());
         if (targetFog != null) {
             fogEvent.setNearPlaneDistance(targetFog.x);
             fogEvent.setFarPlaneDistance(targetFog.y);
-            fogEvent.setCanceled(true);
+            // dannyb - no longer exists
+            // fogEvent.setCanceled(true);
         }
     }
 


### PR DESCRIPTION
Consider it a hopefully helpful starting point - it should contain most of the changes necessary for 1.21.10, except for some fog work and maybe some gui work.  I have only tested the fabric version.

Notes:

1. I didn't try to figure out the min versions of neoforge/fabric/loom that support 1.21.10, i just picked the latest versions as of a few days ago.

2. Getting fog coloring going again requires dealing with the change to use fogenvironments.  I did some but left a bunch undone.  Most color modification should be done in FogEnvironment instead of FogRenderer.  The annoying one here is that renderLevel doesn't directly render terrain fog anymore.  So modification of terrain fog coloring probably needs to be done through injection into the terrain related fog environments.

3. I updated all the gui related injections i could find to deal with how gui state was encapsulated.  It was not obvious how to still allow changing of title color or label color (they don't seem to separately exist in the rendering classes anymore, but i didn't look super hard).

4.  Two of the smithing screen injections seem unnecessary now, but i don't have anything that uses it so i couldn't check.

5.  I updated the compound reloader for changes to the partial reloader.
