### PR TITLE
Added compat for Serene Seasons

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/polytone/PlatStuff.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/PlatStuff.java
@@ -29,6 +29,7 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ColorResolver;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.block.Block;
@@ -161,6 +162,11 @@ public class PlatStuff {
 
     @ExpectPlatform
     public static float compatACModifyGamma(float partialTicks, float gamma) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static float compatSSGetSeason(Level level) {
         throw new AssertionError();
     }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/block/BlockContextExpression.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/block/BlockContextExpression.java
@@ -66,6 +66,7 @@ public class BlockContextExpression extends PolytoneExpression {
         if (hasDayTime) vb.setVariable(DAY_TIME, ClientFrameTicker.getDayTime());
         if (hasSunTime) vb.setVariable(SUN_TIME, ClientFrameTicker.getSunTime());
         if (hasRain) vb.setVariable(RAIN, ClientFrameTicker.getRainAndThunder());
+        if (hasSeason) vb.setVariable(SEASON, ClientFrameTicker.getSeason());
 
         if (hasSkyLight) vb.setVariable(SKY_LIGHT, level.getBrightness(LightLayer.SKY, p));
         if (hasBlockLight) vb.setVariable(BLOCK_LIGHT, level.getBrightness(LightLayer.BLOCK, p));
@@ -111,6 +112,7 @@ public class BlockContextExpression extends PolytoneExpression {
         if (hasDayTime) vars.setVariable(DAY_TIME, ClientFrameTicker.getDayTime());
         if (hasSunTime) vars.setVariable(SUN_TIME, ClientFrameTicker.getSunTime());
         if (hasRain) vars.setVariable(RAIN, ClientFrameTicker.getRainAndThunder());
+        if (hasSeason) vars.setVariable(SEASON, ClientFrameTicker.getSeason());
 
         if (hasSkyLight) vars.setVariable(SKY_LIGHT, level.getBrightness(LightLayer.SKY, pos));
         if (hasBlockLight) vars.setVariable(BLOCK_LIGHT, level.getBrightness(LightLayer.BLOCK, pos));

--- a/common/src/main/java/net/mehvahdjukaar/polytone/colormap/ColormapColorModulatorExpression.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/colormap/ColormapColorModulatorExpression.java
@@ -108,6 +108,7 @@ public class ColormapColorModulatorExpression {
             if (hasDayTime) vb.setVariable(PolytoneExpression.DAY_TIME, ClientFrameTicker.getDayTime());
             if (hasSunTime) vb.setVariable(SUN_TIME, ClientFrameTicker.getSunTime());
             if (hasRain) vb.setVariable(RAIN, ClientFrameTicker.getRainAndThunder());
+            if (hasSeason) vb.setVariable(PolytoneExpression.SEASON, ClientFrameTicker.getSeason());
 
             if (hasSkyLight)
                 vb.setVariable(SKY_LIGHT, Minecraft.getInstance().level.getBrightness(LightLayer.SKY, pos));

--- a/common/src/main/java/net/mehvahdjukaar/polytone/colormap/ColormapExpressionProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/colormap/ColormapExpressionProvider.java
@@ -101,6 +101,7 @@ public class ColormapExpressionProvider extends PolytoneExpression implements IC
         if (hasDayTime) vb.setVariable(PolytoneExpression.DAY_TIME, ClientFrameTicker.getDayTime());
         if (hasSunTime) vb.setVariable(SUN_TIME, ClientFrameTicker.getSunTime());
         if (hasRain) vb.setVariable(RAIN, ClientFrameTicker.getRainAndThunder());
+        if (hasSeason) vb.setVariable(PolytoneExpression.SEASON, ClientFrameTicker.getSeason());
 
         if (hasSkyLight)
             vb.setVariable(SKY_LIGHT, Minecraft.getInstance().level.getBrightness(LightLayer.SKY, pos));

--- a/common/src/main/java/net/mehvahdjukaar/polytone/colormap/IColormapNumberProvider.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/colormap/IColormapNumberProvider.java
@@ -177,4 +177,25 @@ public interface IColormapNumberProvider {
         }
     });
 
+    IColormapNumberProvider SEASON = BUILTIN_PROVIDERS.register("season", new IColormapNumberProvider() {
+        @Override
+        public float getValue(@Nullable BlockState state, @Nullable BlockPos pos, @Nullable Biome biome, @Nullable BiomeIdMapper mapper, @Nullable ItemStack stack) {
+            return 1 - ClientFrameTicker.getSeason();
+        }
+
+        @Override
+        public boolean usesBiome() {
+            return false;
+        }
+
+        @Override
+        public boolean usesPos() {
+            return false;
+        }
+
+        @Override
+        public boolean usesState() {
+            return false;
+        }
+    });
 }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleContextExpression.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/particle/ParticleContextExpression.java
@@ -110,6 +110,7 @@ public class ParticleContextExpression extends PolytoneExpression {
         if (hasDayTime) vb.setVariable(PolytoneExpression.DAY_TIME, ClientFrameTicker.getDayTime());
         if (hasSunTime) vb.setVariable(SUN_TIME, ClientFrameTicker.getSunTime());
         if (hasRain) vb.setVariable(RAIN, ClientFrameTicker.getRainAndThunder());
+        if (hasSeason) vb.setVariable(PolytoneExpression.SEASON, ClientFrameTicker.getSeason());
 
         if (hasSkyLight)
             vb.setVariable(SKY_LIGHT, level.getBrightness(LightLayer.SKY, pos));

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/ClientFrameTicker.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/ClientFrameTicker.java
@@ -1,5 +1,6 @@
 package net.mehvahdjukaar.polytone.utils;
 
+import net.mehvahdjukaar.polytone.PlatStuff;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
@@ -14,6 +15,7 @@ public class ClientFrameTicker {
     private static double timeOfDay;
     private static double dayTime;
     private static float rainAndThunder;
+    private static float season;
     private static int skyLight;
     private static int blockLight;
     private static BlockPos cameraPos = BlockPos.ZERO;
@@ -35,6 +37,7 @@ public class ClientFrameTicker {
         dayTime = level.dimensionType().fixedTime().orElse(level.getDayTime()) + partialTicks;
         timeOfDay = level.getTimeOfDay(partialTicks);
         rainAndThunder = level.getRainLevel(partialTicks) * 0.5f + level.getThunderLevel(partialTicks) * 0.5f;
+        season = PlatStuff.compatSSGetSeason(level);
 
         cameraPos = mc.gameRenderer.getMainCamera().getBlockPosition();
         cameraBiome = level.getBiome(cameraPos);
@@ -113,5 +116,9 @@ public class ClientFrameTicker {
 
     public static float getGuiTime() {
         return screenTime;
+    }
+
+    public static float getSeason() {
+        return season;
     }
 }

--- a/common/src/main/java/net/mehvahdjukaar/polytone/utils/exp/PolytoneExpression.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/utils/exp/PolytoneExpression.java
@@ -19,6 +19,7 @@ public abstract class PolytoneExpression {
     protected static final String DAY_TIME = "DAY_TIME";
     protected static final String SUN_TIME = "SUN_TIME";
     protected static final String RAIN = "RAIN";
+    protected static final String SEASON = "SEASON";
 
     // at pos stuff
     protected static final String POS_X = "POS_X";
@@ -76,6 +77,7 @@ public abstract class PolytoneExpression {
     protected final boolean hasDayTime;
     protected final boolean hasSunTime;
     protected final boolean hasRain;
+    protected final boolean hasSeason;
 
     protected final boolean hasSkyLight;
     protected final boolean hasBlockLight;
@@ -111,6 +113,7 @@ public abstract class PolytoneExpression {
         this.hasDayTime = unparsed.contains(DAY_TIME);
         this.hasSunTime = unparsed.contains(SUN_TIME);
         this.hasRain = unparsed.contains(RAIN);
+        this.hasSeason = unparsed.contains(SEASON);
 
         this.hasSkyLight = unparsed.contains(SKY_LIGHT);
         this.hasBlockLight = unparsed.contains(BLOCK_LIGHT);
@@ -127,7 +130,7 @@ public abstract class PolytoneExpression {
     protected abstract PolytoneExpression createConcurrent();
 
     protected void buildVars(VarBuilder builder) {
-        builder.addAll(POS_X, POS_Y, POS_Z, RAIN, DAY_TIME, SUN_TIME, TIME,
+        builder.addAll(POS_X, POS_Y, POS_Z, RAIN, DAY_TIME, SUN_TIME, TIME, SEASON,
                 TEMPERATURE, DOWNFALL, BLOCK_LIGHT, SKY_LIGHT,
                 DISTANCE_SQUARED, PLAYER_X, PLAYER_Y, PLAYER_Z, PLAYER_SPEED_SQUARED, RENDER_DISTANCE);
     }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -86,5 +86,6 @@ dependencies {
     //modImplementation "curse.maven:continuity-531351:5425853"
     modCompileOnly("curse.maven:sodium-394468:6211305")
    // modImplementation "curse.maven:distant-horizons-508933:6387715"
+    modCompileOnly "curse.maven:serene-seasons-291874:6182595"
 }
 

--- a/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PlatStuffImpl.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/polytone/fabric/PlatStuffImpl.java
@@ -59,11 +59,13 @@ import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ColorResolver;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
+import sereneseasons.api.season.SeasonHelper;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -254,6 +256,12 @@ public class PlatStuffImpl {
 
     public static float compatACModifyGamma(float partialTicks, float gamma) {
         return gamma;
+    }
+
+    private static final boolean SS = FabricLoader.getInstance().isModLoaded("sereneseasons");
+
+    public static float compatSSGetSeason(Level level) {
+        return SS ? (SeasonHelper.getSeasonState(level).getSubSeason().ordinal() / 11f) : 1f;
     }
 
     public static ParticleProvider<?> getParticleProvider(ParticleType<?> type) {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     modCompileOnly("curse.maven:citadel-331936:4786380")
     //modCompileOnly ("org.embeddedt:embeddium-1.21:1.0.7+mc1.21")
     modCompileOnly("curse.maven:farmers-delight-398521:5772720")
-
+    modCompileOnly "curse.maven:serene-seasons-291874:6182596"
 
     implementation 'org.jetbrains:annotations:22.0.0'
 }

--- a/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PlatStuffImpl.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/polytone/neoforge/PlatStuffImpl.java
@@ -40,6 +40,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ColorResolver;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.block.Block;
@@ -59,6 +60,7 @@ import net.neoforged.neoforge.common.CreativeModeTabRegistry;
 import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.joml.Vector3f;
+import sereneseasons.api.season.SeasonHelper;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -299,6 +301,13 @@ public class PlatStuffImpl {
 
     public static float compatACModifyGamma(float partialTicks, float gamma) {
         return AC ? AlexsCavesCompat.modifyGamma(partialTicks, gamma) : gamma;
+    }
+
+
+    private static final boolean SS = ModList.get().isLoaded("sereneseasons");
+
+    public static float compatSSGetSeason(Level level) {
+        return SS ? (SeasonHelper.getSeasonState(level).getSubSeason().ordinal() / 11f) : 1f;
     }
 
 


### PR DESCRIPTION
Allows you to adjust season colours using Polytone's colourmaps & use the season in expressions for block modifiers, custom particles, etc.

Example colourmap:
```json
{
  "x_axis": "biome_id",
  "y_axis": "season",
  "biome_id_mapper": "test:biome_mapper"
}
```