### PR TITLE
Fix broken particles

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
@@ -37,16 +37,18 @@ public class PolytoneRenderTypes extends RenderType {
 
         @Override
         public BufferBuilder begin(Tesselator builder, TextureManager textureManager) {
-            // Normally the modifyParticleConsumer redirect sends these vertices to DEFERRED_BUFFER_SOURCE,
-            // leaving this buffer empty. However, mods that optimize particle rendering (e.g. Sodium) may
-            // short-circuit SingleQuadParticle#renderRotatedQuad before our redirect runs, causing geometry
-            // to land here instead. Set up the additive-translucent state so such a stray draw is correct
-            // rather than rendered with leftover shader/blend state (which showed up as corrupted particles).
+          /*
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
+            RenderSystem.activeTexture(GL13.GL_TEXTURE2);
+            RenderSystem.activeTexture(GL13.GL_TEXTURE0);
+            //because of custom render type fuckery...
             RenderSystem.setShader(() -> noAlphaCutoffShader);
             RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
+
+           */
             return builder.begin(VertexFormat.Mode.QUADS, PARTICLE);
         }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/PolytoneRenderTypes.java
@@ -37,18 +37,16 @@ public class PolytoneRenderTypes extends RenderType {
 
         @Override
         public BufferBuilder begin(Tesselator builder, TextureManager textureManager) {
-          /*
-            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
-            RenderSystem.activeTexture(GL13.GL_TEXTURE2);
-            RenderSystem.activeTexture(GL13.GL_TEXTURE0);
-            //because of custom render type fuckery...
+            // Normally the modifyParticleConsumer redirect sends these vertices to DEFERRED_BUFFER_SOURCE,
+            // leaving this buffer empty. However, mods that optimize particle rendering (e.g. Sodium) may
+            // short-circuit SingleQuadParticle#renderRotatedQuad before our redirect runs, causing geometry
+            // to land here instead. Set up the additive-translucent state so such a stray draw is correct
+            // rather than rendered with leftover shader/blend state (which showed up as corrupted particles).
             RenderSystem.setShader(() -> noAlphaCutoffShader);
             RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
-
-           */
             return builder.begin(VertexFormat.Mode.QUADS, PARTICLE);
         }
 

--- a/common/src/main/java/net/mehvahdjukaar/polytone/content/particle/CustomParticleType.java
+++ b/common/src/main/java/net/mehvahdjukaar/polytone/content/particle/CustomParticleType.java
@@ -312,6 +312,22 @@ public class CustomParticleType implements CustomParticleFactory {
             }
         }
 
+        // Particle-rendering optimizations (e.g. Sodium) inject at HEAD of
+        // SingleQuadParticle#renderRotatedQuad(VertexConsumer, Camera, Quaternionf, float) and cancel it,
+        // emitting a default quad directly. That bypasses our 6-arg renderRotatedQuad override below, where the
+        // additive-translucent consumer redirect and the custom offset are applied. By overriding this overload
+        // ourselves (mirroring vanilla) and not calling super, that fast path no longer targets our particles,
+        // so the redirect and offset run as intended, with or without such mods installed.
+        // See https://github.com/CaffeineMC/sodium/issues/3750
+        @Override
+        protected void renderRotatedQuad(VertexConsumer consumer, Camera camera, Quaternionf quaternion, float partialTicks) {
+            Vec3 cameraPos = camera.getPosition();
+            float x = (float) (Mth.lerp(partialTicks, this.xo, this.x) - cameraPos.x());
+            float y = (float) (Mth.lerp(partialTicks, this.yo, this.y) - cameraPos.y());
+            float z = (float) (Mth.lerp(partialTicks, this.zo, this.z) - cameraPos.z());
+            this.renderRotatedQuad(consumer, quaternion, x, y, z, partialTicks);
+        }
+
         @Override
         protected void renderRotatedQuad(VertexConsumer consumer, Quaternionf quaternion, float x, float y, float z, float partialTicks) {
             Vec3 offset = this.type.offset;


### PR DESCRIPTION
Fixes https://github.com/CaffeineMC/sodium/issues/3750
Fixes https://github.com/MehVahdJukaar/polytone/issues/352 (I tested using VFX+, where the problem manifests itself somewhat differently, but I believe the issue is related)

In summary, the problem was that polytone is doing things in a method that sodium doesn't run because we perform an optimization of particle rendering by running our own code instead, leading to corruption when both mods are trying to do something to this method.

I have included two different ways of fixing this:
- restoring the GL state so inadvertently rendered particles render correctly: https://github.com/MehVahdJukaar/polytone/commit/c521326c1dcaf4d30ec8e727673190ee3e9f94f9. I don't know why this code was commented out, but uncommenting it fixes the problem as far as I can tell.
- avoiding the optimizations sodium does to particles: https://github.com/MehVahdJukaar/polytone/commit/cd37ec8c1960d377e52b1704009a700821b43516. This also fixes the problem without uncommenting the commented out code.

If you merge the PR, the latter solution is implemented. Alternatively, you can cherry pick the first commit to use it.